### PR TITLE
More meaningful parser error messages

### DIFF
--- a/src/main/scala/org/tygus/suslik/logic/SpatialFormulas.scala
+++ b/src/main/scala/org/tygus/suslik/logic/SpatialFormulas.scala
@@ -2,6 +2,7 @@ package org.tygus.suslik.logic
 
 import org.tygus.suslik.language._
 import org.tygus.suslik.language.Expressions._
+import org.tygus.suslik.synthesis.SynthesisException
 import org.tygus.suslik.synthesis.rules.LogicalRules.findMatchingHeaplets
 
 /**
@@ -110,6 +111,9 @@ case class SApp(pred: Ident, args: Seq[Expr], tag: Option[Int] = Some(0)) extend
   def |-(other: Heaplet): Boolean = false
 
   def resolve(gamma: Gamma, env: Environment): Option[Gamma] = {
+    if (!(env.predicates contains  pred)){
+      throw SynthesisException( s"predicate $pred is undefined")
+    }
     val formals = env.predicates(pred).params
 
     if (formals.length == args.length) {

--- a/src/main/scala/org/tygus/suslik/parsing/SSLParser.scala
+++ b/src/main/scala/org/tygus/suslik/parsing/SSLParser.scala
@@ -6,6 +6,8 @@ import org.tygus.suslik.logic._
 import org.tygus.suslik.logic.unification.UnificationGoal
 import org.tygus.suslik.logic.Specifications._
 
+import org.tygus.suslik.synthesis.SynthesisException
+
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
 
 
@@ -111,7 +113,9 @@ class SSLParser extends StandardTokenParsers with SepLogicUtils {
   def program: Parser[Program] = rep(indPredicate | goalFunction) ^^ { pfs =>
     val ps = for (p@InductivePredicate(_, _, _) <- pfs) yield p
     val fs = for (f@FunSpec(_, _, _, _, _) <- pfs) yield f
-    assert(fs.nonEmpty, "No single function spec is provided")
+    if (fs.isEmpty){
+      throw SynthesisException("Parsing failed. No single function spec is provided.")
+    }
     val goal = fs.last
     val funs = fs.take(fs.length - 1)
     Program(ps, funs, goal)

--- a/src/main/scala/org/tygus/suslik/synthesis/SynthesisRunnerUtil.scala
+++ b/src/main/scala/org/tygus/suslik/synthesis/SynthesisRunnerUtil.scala
@@ -66,7 +66,7 @@ trait SynthesisRunnerUtil {
     val parser = new SSLParser
     val res = parser.parseGoal(text)
     if (!res.successful) {
-      throw SynthesisException(s"Failed to parse the input.")
+      throw SynthesisException(s"Failed to parse the input:\n$res")
     }
 
     val prog = res.get

--- a/src/test/scala/org/tygus/suslik/parsing/ParserErrorsTests.scala
+++ b/src/test/scala/org/tygus/suslik/parsing/ParserErrorsTests.scala
@@ -1,0 +1,211 @@
+package org.tygus.suslik.parsing
+
+import org.scalatest.{FunSpec, Matchers}
+import org.tygus.suslik.synthesis.SynthesisException
+import org.tygus.suslik.util.SynLogLevels
+import scala.util.parsing.combinator.Parsers
+
+/**
+  * @author Roman Shchedrin
+  */
+
+class ParserErrorsTests extends FunSpec with Matchers {
+
+  val log = SynLogLevels.Test
+
+  import log._
+
+  val pred1 =
+    """predicate lseg (loc x, loc y) {
+      | x == y  =>  {emp}
+      | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+      }
+
+      {emp} void foo (loc x) {emp}
+    """
+
+  def failsOnLine(code: String, line_no: Int) {
+    val parser = new SSLParser
+    val result = parser.parseGoal(code)
+    assert(!result.successful, "Parser should fail on line " + line_no + "in code \n" + code)
+    result match {
+      case parser.Failure(msg, next) => assert(next.pos.line == line_no,
+        "\nCode\n" + code + "\nshould fail on line " + line_no + " but failed on " + next.pos.line + "\nmessage: " + result)
+      case other => assert(false, other)
+    }
+  }
+
+  describe("Parser syntax errors") {
+    it("should fail with syntax error - 1") {
+      val code = //                    V
+        """predicate lseg (loc x, loc y {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 1)
+    }
+
+    it("should fail with syntax error - 2") {
+      val code = //                     V
+        """predicate lseg (loc x, loc y)
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 2)
+    }
+    it("should fail with syntax error - 3") {
+      val code =
+        """peace lseg (loc x, loc y) {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 1)
+    }
+    it("should fail with syntax error - 4") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x === y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 2)
+    }
+    it("should fail with syntax error - 5") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x ==   =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 2)
+    }
+    it("should fail with syntax error - 6") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  {ep}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 2)
+    }
+
+    it("should fail with syntax error - 7") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 2)
+    }
+
+    it("should fail with syntax error - 8") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :- v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 3)
+    }
+    it("should fail with syntax error - 9") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          {
+
+          {emp} void foo (loc x) {emp}
+        """
+      failsOnLine(code, 4)
+    }
+    it("should fail with syntax error - 10") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp void foo (loc x) {emp}
+        """
+      failsOnLine(code, 6)
+    }
+    it("should fail with syntax error - 11") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} vid foo (loc x) {emp}
+        """
+      failsOnLine(code, 6)
+    }
+    it("should fail with syntax error - 12") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo loc x) {emp}
+        """
+      failsOnLine(code, 6)
+    }
+    it("should fail with syntax error - 13") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x {emp}
+        """
+      failsOnLine(code, 6)
+    }
+    it("should fail with syntax error - 14") {
+      val code =
+        """predicate lseg (loc x, loc y) {
+          | x == y  =>  {emp}
+          | not (x == y)  => {x :-> v ** x + 1 :-> z ** lseg(z, y)}
+          }
+
+          {emp} void foo (loc x) {emp"""
+      failsOnLine(code, 6)
+    }
+
+    it("should throw exception if no goal is given") {
+      val code =
+        """predicate lseg(loc x, set s) {
+        |  x == 0        => { s =i {} ; emp }
+        |  not (x == 0)  => { s =i {v} ++ s1 ; [x, 2] ** x :-> v ** (x + 1) :-> nxt ** lseg(nxt, s1) }
+      }"""
+      intercept[SynthesisException] {
+        val parser = new SSLParser
+        val result = parser.parseGoal(code)
+      }
+    }
+  }
+
+
+}
+


### PR DESCRIPTION
Now parser produces more meaningful messages in case of syntax errors.  I tried it on some incorrect files, and usually the arrow in the error message shows exactly at the point where the mistake is. It doesn't tell the right thing about how to fix it, but this is much better then nothing.