### PR TITLE
Overloaded `==` operator (WIP)

### DIFF
--- a/src/main/scala/org/tygus/suslik/language/Expressions.scala
+++ b/src/main/scala/org/tygus/suslik/language/Expressions.scala
@@ -50,6 +50,7 @@ object Expressions {
     def level: Int = 3
     override def pp: String = "=="
     def lrTypes: List[(SSLType, SSLType)] = List(
+      (BoolType, BoolType),
       (IntType, IntType),
       (IntSetType, IntSetType),
       (LocType, LocType),

--- a/src/main/scala/org/tygus/suslik/language/Expressions.scala
+++ b/src/main/scala/org/tygus/suslik/language/Expressions.scala
@@ -50,12 +50,12 @@ object Expressions {
     def level: Int = 3
     override def pp: String = "=="
     def lrTypes: List[(SSLType, SSLType)] = List(
-      (BoolType, BoolType),
       (IntType, IntType),
       (IntSetType, IntSetType),
       (LocType, LocType),
       (LocType, IntType),
       (IntType, LocType),
+      (BoolType, BoolType),
     )
   }
   object OpLeq extends RelOp {

--- a/src/main/scala/org/tygus/suslik/logic/PureLogicUtils.scala
+++ b/src/main/scala/org/tygus/suslik/logic/PureLogicUtils.scala
@@ -77,16 +77,11 @@ trait PureLogicUtils {
     case UnaryExpr(OpNot, BoolConst(true)) => pFalse
     case UnaryExpr(OpNot, BoolConst(false)) => pTrue
 
-    case BinaryExpr(OpEq, v1@Var(n1), v2@Var(n2)) if n1 == n2 => // remove trivial equality
+    case BinaryExpr(OpOverloadedEq, v1@Var(n1), v2@Var(n2)) if n1 == n2 => // remove trivial equality
       BoolConst(true)
-    case BinaryExpr(OpEq, v1@Var(n1), v2@Var(n2)) => // sort arguments lexicographically
-      if (n1 <= n2) BinaryExpr(OpEq, v1, v2) else BinaryExpr(OpEq, v2, v1)
-    case BinaryExpr(OpEq, e, v@Var(_)) if !e.isInstanceOf[Var] => BinaryExpr(OpEq, v, simplify(e))
-    case BinaryExpr(OpSetEq, v1@Var(n1), v2@Var(n2)) if n1 == n2 => // remove trivial equality
-      BoolConst(true)
-    case BinaryExpr(OpSetEq, v1@Var(n1), v2@Var(n2)) => // sort arguments lexicographically
-      if (n1 <= n2) BinaryExpr(OpSetEq, v1, v2) else BinaryExpr(OpSetEq, v2, v1)
-    case BinaryExpr(OpSetEq, e, v@Var(_)) if !e.isInstanceOf[Var] => BinaryExpr(OpSetEq, v, simplify(e))
+    case BinaryExpr(OpOverloadedEq, v1@Var(n1), v2@Var(n2)) => // sort arguments lexicographically
+      if (n1 <= n2) BinaryExpr(OpOverloadedEq, v1, v2) else BinaryExpr(OpOverloadedEq, v2, v1)
+    case BinaryExpr(OpOverloadedEq, e, v@Var(_)) if !e.isInstanceOf[Var] => BinaryExpr(OpOverloadedEq, v, simplify(e))
 
 
     case BinaryExpr(OpPlus, left, IntConst(i)) if i.toInt == 0 => simplify(left)

--- a/src/main/scala/org/tygus/suslik/logic/smt/SMTSolving.scala
+++ b/src/main/scala/org/tygus/suslik/logic/smt/SMTSolving.scala
@@ -6,6 +6,7 @@ import org.bitbucket.franck44.scalasmt.parser.SMTLIB2Syntax._
 import org.bitbucket.franck44.scalasmt.theories._
 import org.bitbucket.franck44.scalasmt.typedterms.{Commands, QuantifiedTerm, TypedTerm, VarTerm}
 import org.tygus.suslik.language.Expressions._
+import org.tygus.suslik.language.{IntSetType, IntType, BoolType, LocType}
 import org.tygus.suslik.logic._
 
 import scala.util.Success
@@ -90,45 +91,45 @@ object SMTSolving extends Core
   case class SolverUnsupportedExpr(solver: String)
     extends Exception(s"Unsupported solver: $solver.")
 
-  private def convertFormula(phi: PFormula): SMTBoolTerm = convertBoolExpr(phi)
+  private def convertFormula(phi: PFormula, gamma: Gamma): SMTBoolTerm = convertBoolExpr(phi, gamma)
 
-  private def convertSetExpr(e: Expr): SMTSetTerm = e match {
+  private def convertSetExpr(e: Expr, gamma: Gamma): SMTSetTerm = e match {
     case Var(name) => new VarTerm[ SetTerm ]( name, setSort )
     case SetLiteral(elems) => {
       val emptyTerm = new TypedTerm[SetTerm, Term](Set.empty, emptySetTerm)
-      makeSetInsert(emptyTerm, elems)
+      makeSetInsert(emptyTerm, elems, gamma)
     }
     // Special case for unions with a literal
     case BinaryExpr(OpUnion, SetLiteral(elems1), SetLiteral(elems2)) => {
       val emptyTerm = new TypedTerm[SetTerm, Term](Set.empty, emptySetTerm)
-      makeSetInsert(emptyTerm, elems1 ++ elems2)
+      makeSetInsert(emptyTerm, elems1 ++ elems2, gamma)
     }
     case BinaryExpr(OpUnion, left, SetLiteral(elems)) => {
-      val l = convertSetExpr(left)
-      makeSetInsert(l, elems)
+      val l = convertSetExpr(left, gamma)
+      makeSetInsert(l, elems, gamma)
     }
     case BinaryExpr(OpUnion, SetLiteral(elems), right) => {
-      val r = convertSetExpr(right)
-      makeSetInsert(r, elems)
+      val r = convertSetExpr(right, gamma)
+      makeSetInsert(r, elems, gamma)
     }
     case BinaryExpr(OpUnion, left, right) => {
-      val l = convertSetExpr(left)
-      val r = convertSetExpr(right)
+      val l = convertSetExpr(left, gamma)
+      val r = convertSetExpr(right, gamma)
       new TypedTerm[SetTerm, Term](l.typeDefs ++ r.typeDefs, QIdAndTermsTerm(setUnionSymbol, List(l.termDef, r.termDef)))
     }
     case BinaryExpr(OpDiff, left, right) => {
-      val l = convertSetExpr(left)
-      val r = convertSetExpr(right)
+      val l = convertSetExpr(left,gamma)
+      val r = convertSetExpr(right, gamma)
       new TypedTerm[SetTerm, Term](l.typeDefs ++ r.typeDefs, QIdAndTermsTerm(setDiffSymbol, List(l.termDef, r.termDef)))
     }
     case _ => throw SMTUnsupportedExpr(e)
   }
 
-  private def makeSetInsert(setTerm: SMTSetTerm, elems: List[Expr]): SMTSetTerm = {
+  private def makeSetInsert(setTerm: SMTSetTerm, elems: List[Expr], gamma: Gamma): SMTSetTerm = {
     if (elems.isEmpty) {
       setTerm
     } else {
-      val eTerms: List[SMTIntTerm] = elems.map(convertIntExpr)
+      val eTerms: List[SMTIntTerm] = elems.map(convertIntExpr(_, gamma))
       if (defaultSolver == "CVC4") {
         new TypedTerm[SetTerm, Term](setTerm.typeDefs ++ eTerms.flatMap(_.typeDefs).toSet,
           QIdAndTermsTerm(setInsertSymbol, (eTerms :+ setTerm).map(_.termDef)))
@@ -141,65 +142,79 @@ object SMTSolving extends Core
     }
   }
 
-  private def convertBoolExpr(e: Expr): SMTBoolTerm =  e match {
+  private def convertBoolExpr(e: Expr, gamma: Gamma): SMTBoolTerm =  e match {
     case Var(name) => Bools(name)
     case BoolConst(true) => True()
     case BoolConst(false) => False()
-    case UnaryExpr(OpNot, e1) => !convertBoolExpr(e1)
+    case UnaryExpr(OpNot, e1) => !convertBoolExpr(e1, gamma)
     case BinaryExpr(OpAnd, left, right) => {
-      val l = convertBoolExpr(left)
-      val r = convertBoolExpr(right)
+      val l = convertBoolExpr(left, gamma)
+      val r = convertBoolExpr(right, gamma)
       l & r }
     case BinaryExpr(OpOr, left, right) => {
-      val l = convertBoolExpr(left)
-      val r = convertBoolExpr(right)
+      val l = convertBoolExpr(left, gamma)
+      val r = convertBoolExpr(right, gamma)
       l | r }
-    case BinaryExpr(OpEq, left, right) => {
-      val l = convertIntExpr(left)
-      val r = convertIntExpr(right)
+    case BinaryExpr(OpEq1, left, right) => {
+      val l = convertIntExpr(left, gamma)
+      val r = convertIntExpr(right, gamma)
       l === r }
+    case BinaryExpr(OpOverloadedEq, left, right) =>
+      (left.getType(gamma), right.getType(gamma)) match {
+        case (Some(IntSetType), Some(IntSetType)) => convertBoolExpr(BinaryExpr(OpSetEq1, left, right), gamma)
+        case (Some(IntType), Some(IntType))
+             | (Some(LocType), Some(LocType))
+             | (Some(IntType), Some(LocType))
+             | (Some(LocType), Some(IntType))
+        => {
+          convertBoolExpr(BinaryExpr(OpEq1, left, right), gamma)
+        }
+        case other => {
+          throw new RuntimeException("unexpected types for `==` operator: " + other)
+        }
+      }
     case BinaryExpr(OpLeq, left, right) => {
-      val l = convertIntExpr(left)
-      val r = convertIntExpr(right)
+      val l = convertIntExpr(left, gamma)
+      val r = convertIntExpr(right, gamma)
       l <= r }
     case BinaryExpr(OpLt, left, right) => {
-      val l = convertIntExpr(left)
-      val r = convertIntExpr(right)
+      val l = convertIntExpr(left, gamma)
+      val r = convertIntExpr(right, gamma)
       l < r }
     case BinaryExpr(OpIn, left, right) => {
-      val l = convertIntExpr(left)
-      val r = convertSetExpr(right)
+      val l = convertIntExpr(left, gamma)
+      val r = convertSetExpr(right, gamma)
       new TypedTerm[BoolTerm, Term](l.typeDefs ++ r.typeDefs,
         QIdAndTermsTerm(setMemberSymbol, List(l.termDef, r.termDef)))
       }
-    case BinaryExpr(OpSetEq, left, right) => {
-      val l = convertSetExpr(left)
-      val r = convertSetExpr(right)
+    case BinaryExpr(OpSetEq1, left, right) => {
+      val l = convertSetExpr(left, gamma)
+      val r = convertSetExpr(right, gamma)
       l === r }
     case BinaryExpr(OpSubset, left, right) => {
-      val l = convertSetExpr(left)
-      val r = convertSetExpr(right)
+      val l = convertSetExpr(left, gamma)
+      val r = convertSetExpr(right, gamma)
       new TypedTerm[BoolTerm, Term](l.typeDefs ++ r.typeDefs,
         QIdAndTermsTerm(setSubsetSymbol, List(l.termDef, r.termDef)))
     }
     case _ => throw SMTUnsupportedExpr(e)
   }
 
-  private def convertIntExpr(e: Expr): SMTIntTerm = e match {
+  private def convertIntExpr(e: Expr, gamma: Gamma): SMTIntTerm = e match {
     case Var(name) => Ints(name)
     case IntConst(c) => Ints(c)
     case BinaryExpr(op, left, right) => {
-      val l = convertIntExpr(left)
-      val r = convertIntExpr(right)
+      val l = convertIntExpr(left, gamma)
+      val r = convertIntExpr(right, gamma)
       op match {
         case OpPlus => l + r
         case OpMinus => l - r
         case _ => throw SMTUnsupportedExpr(e)
       }}
     case IfThenElse(cond, left, right) => {
-      val c = convertBoolExpr(cond)
-      val l = convertIntExpr(left)
-      val r = convertIntExpr(right)
+      val c = convertBoolExpr(cond, gamma)
+      val l = convertIntExpr(left, gamma)
+      val r = convertIntExpr(right, gamma)
       c.ite(l,r) }
     case _ => throw SMTUnsupportedExpr(e)
   }
@@ -218,13 +233,13 @@ object SMTSolving extends Core
   /** External interface */
 
   // Check if phi is satisfiable; all vars are implicitly existentially quantified
-  def sat(phi: PFormula): Boolean = {
-    cache.getOrElseUpdate(phi, checkSat(convertFormula(phi)))
+  def sat(phi: PFormula, gamma: Gamma): Boolean = {
+    cache.getOrElseUpdate(phi, checkSat(convertFormula(phi, gamma)))
   }
 
   // Check if phi is valid; all vars are implicitly universally quantified
-  def valid(phi: PFormula): Boolean = {
-    !sat(phi.not)
+  def valid(phi: PFormula, gamma: Gamma): Boolean = {
+    !sat(phi.not, gamma)
   }
 
 }

--- a/src/main/scala/org/tygus/suslik/logic/smt/SMTSolving.scala
+++ b/src/main/scala/org/tygus/suslik/logic/smt/SMTSolving.scala
@@ -169,6 +169,11 @@ object SMTSolving extends Core
         => {
           convertBoolExpr(BinaryExpr(OpEq1, left, right), gamma)
         }
+        case (Some(BoolType), Some(BoolType)) =>{
+          val l = convertBoolExpr(left, gamma)
+          val r = convertBoolExpr(right, gamma)
+          l === r
+        }
         case other => {
           throw new RuntimeException("unexpected types for `==` operator: " + other)
         }

--- a/src/main/scala/org/tygus/suslik/parsing/SSLParser.scala
+++ b/src/main/scala/org/tygus/suslik/parsing/SSLParser.scala
@@ -55,7 +55,7 @@ class SSLParser extends StandardTokenParsers with SepLogicUtils {
 
   def termOpParser: Parser[BinOp] = "+" ^^^ OpPlus ||| "-" ^^^ OpMinus ||| "++" ^^^ OpUnion ||| "--" ^^^ OpDiff
 
-  def relOpParser: Parser[BinOp] = "<=" ^^^ OpLeq ||| "<" ^^^ OpLt ||| "==" ^^^ OpEq ||| "=i" ^^^ OpSetEq ||| "<=i" ^^^ OpSubset ||| "in" ^^^ OpIn
+  def relOpParser: Parser[BinOp] = "<=" ^^^ OpLeq ||| "<" ^^^ OpLt ||| "==" ^^^ OpOverloadedEq ||| "=i" ^^^ OpOverloadedEq ||| "<=i" ^^^ OpSubset ||| "in" ^^^ OpIn
 
   def logOpParser: Parser[BinOp] = "\\/" ^^^ OpOr ||| "/\\" ^^^ OpAnd
 

--- a/src/main/scala/org/tygus/suslik/synthesis/Synthesis.scala
+++ b/src/main/scala/org/tygus/suslik/synthesis/Synthesis.scala
@@ -8,6 +8,7 @@ import org.tygus.suslik.logic.smt.SMTSolving
 import org.tygus.suslik.util.{SynLogging, SynStats}
 
 import scala.Console._
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 /**
@@ -50,7 +51,33 @@ trait Synthesis extends SepLogicUtils {
 
   }
 
-  private def synthesize(goal: Goal, depth: Int)
+  var saved_results = scala.collection.mutable.Map[Goal, (Option[Statement], Int)]()
+  private def synthesize(goal: Goal, depth: Int) // todo: add goal normalization
+                        (stats: SynStats,
+                         rules: List[SynthesisRule])
+                        (implicit ind: Int = 0): Option[Statement] = {
+    if(saved_results.contains(goal)){
+      val (res, recalled_count) = saved_results(goal)
+      saved_results(goal) = (res, recalled_count + 1)
+      if (res.isDefined) {
+        stats.bumpUpRecalledResultsPositive()
+      }else{
+        stats.bumpUpRecalledResultsNegative()
+      }
+      res
+    }else{
+      val res = synthesize_actual(goal, depth)(stats, rules)(ind)
+      if (res.isDefined) {
+        stats.bumpUpSavedResultsPositive()
+      }else{
+        stats.bumpUpSavedResultsNegative()
+      }
+      saved_results(goal) = (res,0)
+      res
+    }
+  }
+
+  private def synthesize_actual(goal: Goal, depth: Int)
                         (stats: SynStats,
                          rules: List[SynthesisRule])
                         (implicit ind: Int = 0): Option[Statement] = {

--- a/src/main/scala/org/tygus/suslik/synthesis/SynthesisRunnerUtil.scala
+++ b/src/main/scala/org/tygus/suslik/synthesis/SynthesisRunnerUtil.scala
@@ -97,6 +97,14 @@ trait SynthesisRunnerUtil {
           testPrintln(s"Lasting successful rule applications: ${stats.numLasting}")
           testPrintln(s"Total successful rule applications: ${stats.numSucc}")
           testPrintln(s"Final size of SMT cache: ${stats.smtCacheSize}")
+          testPrintln(s"Number of saved negative results: ${stats.numSavedResultsNegative}")
+          testPrintln(s"Number of saved positive results: ${stats.numSavedResultsPositive}")
+          testPrintln(s"Number of recalled negative results: ${stats.numRecalledResultsNegative}")
+          testPrintln(s"Number of recalled positive results: ${stats.numRecalledResultsPositive}")
+          testPrintln(s"Total number of saved results: ${saved_results.size}")
+          //          for ((goal, (_, count)) <- saved_results if count > 1) {
+          //            testPrintln(s"$count ${goal.pp}")
+          //          }
           testPrintln(result)
           testPrintln("-----------------------------------------------------")
         } else {

--- a/src/main/scala/org/tygus/suslik/synthesis/instances/PhasedSynthesis.scala
+++ b/src/main/scala/org/tygus/suslik/synthesis/instances/PhasedSynthesis.scala
@@ -12,7 +12,7 @@ class PhasedSynthesis(implicit val log: SynLogging) extends Synthesis {
   {
     // Warm-up the SMT solver on start-up to avoid future delays
     for (i <- 1 to 5; j <- 1 to 2; k <- 1 to 3) {
-      sat(BinaryExpr(OpLeq, IntConst(i), BinaryExpr(OpPlus, IntConst(j), IntConst(k))))
+      sat(BinaryExpr(OpLeq, IntConst(i), BinaryExpr(OpPlus, IntConst(j), IntConst(k))), Map.empty)
     }
   }
 

--- a/src/main/scala/org/tygus/suslik/synthesis/rules/UnfoldingRules.scala
+++ b/src/main/scala/org/tygus/suslik/synthesis/rules/UnfoldingRules.scala
@@ -166,7 +166,7 @@ object UnfoldingRules extends SepLogicUtils with RuleUtils {
         sub <- {
           SpatialUnification.unify(target, source).toList
         }
-        if SMTSolving.valid(goal.pre.phi ==> f.pre.phi.subst(sub))
+        if SMTSolving.valid(goal.pre.phi ==> f.pre.phi.subst(sub), goal.gamma)
         args = f.params.map { case (_, x) => x.subst(sub) }
         if args.flatMap(_.vars).toSet.subsetOf(goal.vars)
         callGoal <- mkCallGoal(f, sub, callSubPre, goal)
@@ -232,7 +232,7 @@ object UnfoldingRules extends SepLogicUtils with RuleUtils {
         relaxedSub <- SpatialUnification.unify(target, source)
         // Preserve regular variables and fresh existentials back to what they were, if applicable
         actualSub = relaxedSub.filterNot { case (k, v) => exSub.keySet.contains(k) } ++ compose1(exSub, relaxedSub)
-        if SMTSolving.valid(goal.pre.phi ==> f.pre.phi.subst(actualSub))
+        if SMTSolving.valid(goal.pre.phi ==> f.pre.phi.subst(actualSub), goal.gamma)
         (writeGoalsOpt, restGoal) = writesAndRestGoals(actualSub, relaxedSub, f, goal)
         if writeGoalsOpt.nonEmpty
       } yield {

--- a/src/main/scala/org/tygus/suslik/synthesis/rules/UnificationRules.scala
+++ b/src/main/scala/org/tygus/suslik/synthesis/rules/UnificationRules.scala
@@ -83,9 +83,8 @@ object UnificationRules extends PureLogicUtils with SepLogicUtils with RuleUtils
       def isExsistVar(e: Expr) = e.isInstanceOf[Var] && goal.isExistential(e.asInstanceOf[Var])
 
       findConjunctAndRest({
-        case BinaryExpr(OpEq, l, r) => isExsistVar(l) || isExsistVar(r)
         // TODO [sets]: Can we enable this?
-        case BinaryExpr(OpSetEq, l, r) => isExsistVar(l) || isExsistVar(r)
+        case BinaryExpr(OpOverloadedEq, l, r) => isExsistVar(l) || isExsistVar(r)
         case _ => false
       }, p2) match {
         case Some((BinaryExpr(_, l, r), rest2)) =>

--- a/src/main/scala/org/tygus/suslik/util/SynLogging.scala
+++ b/src/main/scala/org/tygus/suslik/util/SynLogging.scala
@@ -63,6 +63,10 @@ class SynStats {
   private var backtracking: Int = 0
   private var successful: Int = 0
   private var lasting: Int = 0
+  private var saved_results_positive: Int = 0
+  private var saved_results_negative: Int = 0
+  private var recalled_results_positive: Int = 0
+  private var recalled_results_negative: Int = 0
 
   def bumpUpBacktracing() {
     backtracking = backtracking + 1
@@ -76,10 +80,31 @@ class SynStats {
     lasting = lasting + 1
   }
 
+  def bumpUpSavedResultsNegative() {
+    saved_results_negative += 1
+  }
+  def bumpUpRecalledResultsNegative() {
+    recalled_results_negative += 1
+  }
+
+  def bumpUpSavedResultsPositive() {
+    saved_results_positive +=  1
+  }
+  def bumpUpRecalledResultsPositive() {
+    recalled_results_positive +=  1
+  }
+
+
   def numBack: Int = backtracking
   def numSucc : Int = successful
   def numLasting : Int = lasting
+  def numSavedResultsPositive : Int = saved_results_positive
+  def numRecalledResultsPositive : Int = recalled_results_positive
+  def numSavedResultsNegative : Int = saved_results_negative
+  def numRecalledResultsNegative : Int = recalled_results_negative
   def smtCacheSize: Int = SMTSolving.cacheSize
+  var total_goals_saved = 0
+
 }
 
 abstract sealed class SynCertificate


### PR DESCRIPTION
I replaced almost everywhere OpEq and OpSetEq with OpOverloadedEq.
To make it work, I needed to know types of left and right sub-expressions, and this requires to know gamma. So I passed gamma as a parameter to function `convertBoolExpr` and every function that calls `convertBoolExpr`, and every function that calls that functions, up to `SMTSolving.sat` and `SMTSolving.valid`. I also introduced some changes in function `resolve`  to correctly work with overloaded operators. 
Let me know If you think this is the right approach to make overloaded operators, and I will modify the rest in the same way. 
I haven't yet learned how to make a PR properly, and the diff still shows changes from `parser` branch, sorry, I'll fix it tomorrow. 